### PR TITLE
Only install current exe in build.zig

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -32,10 +32,11 @@ pub fn build(b: *std.Build) void {
                 },
             }),
         });
-
-        b.installArtifact(exe);
-
+        
         const run_step = b.step(info.name, "Run the " ++ info.name);
+
+        const install_artifact = b.addInstallArtifact(exe, .{});
+        run_step.dependOn(&install_artifact.step);
 
         const run_cmd = b.addRunArtifact(exe);
         run_step.dependOn(&run_cmd.step);


### PR DESCRIPTION
The `bank_2pc` demo doesn't compile with Zig 0.15.1. This would normally be fine if you aren't building `bank_2pc`, but since every executable is built and installed no matter which demo you build, no demos are currently runnable with Zig 0.15.1.

We now only compile/install the demo you are building, eliminating this class of issue.